### PR TITLE
Add regex check for whitespace olines

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add patterns in ~/.gitignore to wildignore.
 let g:RootIgnoreAgignore = 1
 (Default: 0)
 ```
-**Requirement**: [**ag**](https://github.com/ggreer/the_silver_searcher)  
+**Requirement**: [**ag**](https://github.com/ggreer/the_silver_searcher)
 Let RootIgnore set `ctrlp's g:ctrlp_user_command` to use **ag** for
 faster search.
 
@@ -52,6 +52,8 @@ let g:CommandTWildIgnore = &wildignore . ',myPattern"
 
 ## Update
 
+- **01-16-2018**
+  - Add regex whitespace ignore so whitespace lines in .gitignore aren't added to wildignore.
 - **08-07-2015**
   - Fix a bug for using .gitignore in non-git folder.
 - **07-27-2015**

--- a/plugin/RootIgnore.vim
+++ b/plugin/RootIgnore.vim
@@ -23,9 +23,10 @@ function! s:WildignoreFromGitignore(gitpath, isAtRoot)
     for oline in readfile(gitignore)
 
       let line = substitute(oline, '\s|\n|\r', '', "g")
-      if line =~ '^#' | con | endif
-      if line == ''   | con | endif
-      if line =~ '^!' | con | endif
+      if line =~ '^#'   | con | endif
+      if line == ''     | con | endif
+      if line =~ '^!'   | con | endif
+      if line =~ '^\s$' | con | endif
 
 
       if a:isAtRoot


### PR DESCRIPTION
Currently an error will occur if a .gitignore contains lines with
whitespace as it attempts to set wildignore with , , (for example)